### PR TITLE
COV-25: front end submit status page

### DIFF
--- a/client/src/assets/scss/style.scss
+++ b/client/src/assets/scss/style.scss
@@ -86,6 +86,11 @@ input[type="checkbox"] {
   .card-title {
     font-size: 15px;
   }
+
+  .card-body,
+  .card-footer {
+    padding: 17px;
+  }
 }
 
 .status-report-fields-card {

--- a/client/src/layouts/VerticalLayout.js
+++ b/client/src/layouts/VerticalLayout.js
@@ -1,17 +1,40 @@
 import Layout from "@layouts/VerticalLayout";
 import navigation from "@src/navigation/vertical";
 import { Link } from "react-router-dom";
-import { Fragment } from "react";
+import { Fragment, useEffect } from "react";
 import { NavItem, NavLink } from "reactstrap";
 import { handleLogout } from "@store/authentication";
 import { UncontrolledDropdown, DropdownMenu, DropdownToggle, DropdownItem } from "reactstrap";
 import { useDispatch, useSelector } from "react-redux";
+import axios from "axios";
+import { handleProfile } from "@store/authentication";
 
 const selectUser = (state) => state.auth.userData.user;
+const selectToken = (state) => state.auth.userData.token;
+
+async function getProfile(token) {
+    const res = await axios.get("http://localhost:8080/users/me", {
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    });
+
+    return res.data;
+}
 
 const CustomNavbar = () => {
     const dispatch = useDispatch();
     const user = useSelector(selectUser);
+    const token = useSelector(selectToken);
+
+    useEffect(() => {
+        async function f() {
+            const userData = await getProfile(token);
+            dispatch(handleProfile({ user: userData }));
+            console.log(userData);
+        }
+        f();
+    }, [dispatch, token]);
 
     const logoIcon = (
         <svg width="28" height="32" viewBox="0 0 28 32" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/client/src/navigation/vertical/index.js
+++ b/client/src/navigation/vertical/index.js
@@ -42,7 +42,7 @@ export default [
         id: "patient",
         title: "Patient",
         icon: <Heart />,
-        accessibleBy: ["ADMIN", "DOCTOR"],
+        accessibleBy: ["ADMIN", "DOCTOR", "PATIENT"],
         children: [
             {
                 id: "assignDoctor",
@@ -57,6 +57,13 @@ export default [
                 icon: <Circle />,
                 navLink: "/define_status_report",
                 accessibleBy: ["DOCTOR"],
+            },
+            {
+                id: "statusReport",
+                title: "Status Report",
+                icon: <Circle />,
+                navLink: "/status_report",
+                accessibleBy: ["PATIENT"],
             },
         ],
     },

--- a/client/src/redux/authentication.js
+++ b/client/src/redux/authentication.js
@@ -30,9 +30,18 @@ export const authSlice = createSlice({
             state.userData = {};
             localStorage.removeItem("userData");
         },
+        handleProfile: (state, action) => {
+            state.userData = {
+                ...state.userData,
+                user: {
+                    ...state.userData.user,
+                    ...action.payload.user,
+                },
+            };
+        },
     },
 });
 
-export const { handleLogin, handleLogout } = authSlice.actions;
+export const { handleLogin, handleLogout, handleProfile } = authSlice.actions;
 
 export default authSlice.reducer;

--- a/client/src/router/routes/Pages.js
+++ b/client/src/router/routes/Pages.js
@@ -23,6 +23,20 @@ const PagesRoutes = [
         },
     },
     {
+        path: "/define_status_report",
+        component: lazy(() => import("../../views/pages/patient/DefineStatusReport")),
+        meta: {
+            accessibleBy: ["DOCTOR"],
+        },
+    },
+    {
+        path: "/status_report",
+        component: lazy(() => import("../../views/pages/patient/StatusReport")),
+        meta: {
+            accessibleBy: ["PATIENT"],
+        },
+    },
+    {
         path: "/sign_in",
         component: lazy(() => import("../../views/pages/authentication/SignIn")),
         layout: "BlankLayout",
@@ -43,13 +57,6 @@ const PagesRoutes = [
         component: lazy(() => import("../../views/pages/user/RoleChange")),
         meta: {
             accessibleBy: ["ADMIN"],
-        },
-    },
-    {
-        path: "/define_status_report",
-        component: lazy(() => import("../../views/pages/patient/DefineStatusReport")),
-        meta: {
-            accessibleBy: ["DOCTOR"],
         },
     },
     {

--- a/client/src/router/routes/Pages.js
+++ b/client/src/router/routes/Pages.js
@@ -41,10 +41,16 @@ const PagesRoutes = [
     {
         path: "/assign_role",
         component: lazy(() => import("../../views/pages/user/RoleChange")),
+        meta: {
+            accessibleBy: ["ADMIN"],
+        },
     },
     {
         path: "/define_status_report",
         component: lazy(() => import("../../views/pages/patient/DefineStatusReport")),
+        meta: {
+            accessibleBy: ["DOCTOR"],
+        },
     },
     {
         path: "/misc/not-authorized",

--- a/client/src/views/pages/authentication/SignIn.js
+++ b/client/src/views/pages/authentication/SignIn.js
@@ -35,6 +35,7 @@ const SignIn = () => {
     const defaultValues = {
         password: "",
         email: "",
+        rememberMe: true,
     };
 
     const SignInSchema = yup.object().shape({
@@ -133,7 +134,9 @@ const SignIn = () => {
                                         id="rememberMe"
                                         name="rememberMe"
                                         control={control}
-                                        render={({ field }) => <Input type="checkbox" id="remember-me" {...field} />}
+                                        render={({ field }) => (
+                                            <Input type="checkbox" id="remember-me" checked={field.value} {...field} />
+                                        )}
                                     />
                                     <Label className="form-check-label" for="remember-me">
                                         Remember Me

--- a/client/src/views/pages/patient/DefineStatusReport.js
+++ b/client/src/views/pages/patient/DefineStatusReport.js
@@ -170,12 +170,7 @@ function DefineStatusReport() {
                                         name="temperature"
                                         control={control}
                                         render={({ field }) => (
-                                            <Input
-                                                type="checkbox"
-                                                defaultChecked={field.value}
-                                                disabled={true}
-                                                {...field}
-                                            />
+                                            <Input type="checkbox" checked={field.value} disabled={true} {...field} />
                                         )}
                                     />
                                     <Label className="form-check-label">Temperature</Label>
@@ -186,12 +181,7 @@ function DefineStatusReport() {
                                         name="weight"
                                         control={control}
                                         render={({ field }) => (
-                                            <Input
-                                                type="checkbox"
-                                                defaultChecked={field.value}
-                                                disabled={true}
-                                                {...field}
-                                            />
+                                            <Input type="checkbox" checked={field.value} disabled={true} {...field} />
                                         )}
                                     />
                                     <Label className="form-check-label">Weight</Label>
@@ -212,7 +202,7 @@ function DefineStatusReport() {
                                                     type="checkbox"
                                                     className="form-check-input"
                                                     disabled={fieldData.disabled}
-                                                    defaultChecked={field.value}
+                                                    checked={field.value}
                                                     {...field}
                                                 />
                                             )}
@@ -234,7 +224,7 @@ function DefineStatusReport() {
                                                     type="checkbox"
                                                     className="form-check-input"
                                                     disabled={fieldData.disabled}
-                                                    defaultChecked={field.value}
+                                                    checked={field.value}
                                                     {...field}
                                                 />
                                             )}

--- a/client/src/views/pages/patient/DefineStatusReport.js
+++ b/client/src/views/pages/patient/DefineStatusReport.js
@@ -109,6 +109,7 @@ function DefineStatusReport() {
     const {
         control,
         handleSubmit,
+        reset,
         formState: { errors },
     } = useForm({ defaultValues, resolver: yupResolver(defineStatusReportSchema) });
 
@@ -127,6 +128,8 @@ function DefineStatusReport() {
                 autoClose: 5000,
             });
         }
+
+        reset();
     };
 
     return (

--- a/client/src/views/pages/patient/StatusReport.js
+++ b/client/src/views/pages/patient/StatusReport.js
@@ -1,0 +1,257 @@
+import BreadCrumbsPage from "@components/breadcrumbs";
+import { Button, Card, CardBody, CardFooter, CardTitle, Form, FormFeedback, Input, Label } from "reactstrap";
+import { Controller, useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
+import axios from "axios";
+import { useSelector } from "react-redux";
+import { toast } from "react-toastify";
+
+async function defineStatusReport(data, token) {
+    const { patientId, ...fields } = data;
+    await axios.post(
+        `http://localhost:8080/patients/${patientId}/statuses/fields`,
+        {
+            ...fields,
+        },
+        {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        },
+    );
+}
+
+const selectToken = (state) => state.auth.userData.token;
+
+function StatusReport() {
+    const defaultValues = {
+        patientId: "",
+        temperature: true,
+        weight: true,
+        fever: false,
+        cough: false,
+        shortnessOfBreath: false,
+        lossOfTasteAndSmell: false,
+        nausea: false,
+        stomachAches: false,
+        vomiting: false,
+        headache: false,
+        musclePain: false,
+        soreThroat: false,
+        otherSymptoms: true,
+    };
+
+    const defineStatusReportSchema = yup.object().shape({
+        patientId: yup.number("Enter a patient ID.").typeError("Enter a patient ID.").required("Enter a patient ID."),
+    });
+
+    const primarySymptoms = [
+        {
+            name: "Fever",
+            id: "fever",
+            disabled: false,
+        },
+        {
+            name: "Cough",
+            id: "cough",
+            disabled: false,
+        },
+        {
+            name: "Shortness of Breath",
+            id: "shortnessOfBreath",
+            disabled: false,
+        },
+        {
+            name: "Loss of Taste and Smell",
+            id: "lossOfTasteAndSmell",
+            disabled: false,
+        },
+    ];
+    const secondarySymptoms = [
+        {
+            name: "Nausea",
+            id: "nausea",
+            disabled: false,
+        },
+        {
+            name: "Stomach Aches",
+            id: "stomachAches",
+            disabled: false,
+        },
+        {
+            name: "Vomiting",
+            id: "vomiting",
+            disabled: false,
+        },
+        {
+            name: "Headache",
+            id: "headache",
+            disabled: false,
+        },
+        {
+            name: "Muscle Pain",
+            id: "musclePain",
+            disabled: false,
+        },
+        {
+            name: "Sore Throat",
+            id: "soreThroat",
+            disabled: false,
+        },
+        {
+            name: "Other Symptoms",
+            id: "otherSymptoms",
+            disabled: true,
+        },
+    ];
+
+    const {
+        control,
+        handleSubmit,
+        reset,
+        formState: { errors },
+    } = useForm({ defaultValues, resolver: yupResolver(defineStatusReportSchema) });
+
+    const token = useSelector(selectToken);
+
+    const onSubmit = async (data) => {
+        try {
+            await defineStatusReport(data, token);
+            toast.success("Status Report Defined for a Patient", {
+                position: "top-right",
+                autoClose: 5000,
+            });
+        } catch (error) {
+            toast.error("Status report could not be defined", {
+                position: "top-right",
+                autoClose: 5000,
+            });
+        }
+
+        reset();
+    };
+
+    return (
+        <div>
+            <BreadCrumbsPage
+                breadCrumbTitle="Define Status Report"
+                breadCrumbParent="Patient"
+                breadCrumbActive="Define Status Report"
+            />
+            <Card className="basic-card status-report-fields-card mx-auto">
+                <CardBody>
+                    <CardTitle className="mb-0">Define Status Report for a Patient</CardTitle>
+                </CardBody>
+                <CardFooter>
+                    <Form>
+                        <div className="mb-1">
+                            <Label className="form-label" for="patientId">
+                                Patient ID
+                            </Label>
+                            <Controller
+                                id="patientId"
+                                name="patientId"
+                                control={control}
+                                render={({ field }) => (
+                                    <Input autoFocus type="number" invalid={!!errors.patientId} {...field} />
+                                )}
+                            />
+                            {errors.patientId && (
+                                <FormFeedback className="d-block">{errors.patientId.message}</FormFeedback>
+                            )}
+                        </div>
+                        <div className="mb-1">
+                            <Label className="form-label">General</Label>
+                            <div className="d-flex">
+                                <div className="form-check w-50">
+                                    <Controller
+                                        id="temperature"
+                                        name="temperature"
+                                        control={control}
+                                        render={({ field }) => (
+                                            <Input
+                                                type="checkbox"
+                                                defaultChecked={field.value}
+                                                disabled={true}
+                                                {...field}
+                                            />
+                                        )}
+                                    />
+                                    <Label className="form-check-label">Temperature</Label>
+                                </div>
+                                <div className="form-check w-50">
+                                    <Controller
+                                        id="weight"
+                                        name="weight"
+                                        control={control}
+                                        render={({ field }) => (
+                                            <Input
+                                                type="checkbox"
+                                                defaultChecked={field.value}
+                                                disabled={true}
+                                                {...field}
+                                            />
+                                        )}
+                                    />
+                                    <Label className="form-check-label">Weight</Label>
+                                </div>
+                            </div>
+                        </div>
+                        <div className="d-flex">
+                            <div className="w-50 me-1">
+                                <Label className="form-label">Primary Symptoms</Label>
+                                {primarySymptoms.map((fieldData, key) => (
+                                    <div className="form-check" key={key}>
+                                        <Controller
+                                            id={fieldData.id}
+                                            name={fieldData.id}
+                                            control={control}
+                                            render={({ field }) => (
+                                                <Input
+                                                    type="checkbox"
+                                                    className="form-check-input"
+                                                    disabled={fieldData.disabled}
+                                                    defaultChecked={field.value}
+                                                    {...field}
+                                                />
+                                            )}
+                                        />
+                                        <Label className="form-check-label">{fieldData.name}</Label>
+                                    </div>
+                                ))}
+                            </div>
+                            <div>
+                                <Label className="form-label">Secondary Symptoms</Label>
+                                {secondarySymptoms.map((fieldData, key) => (
+                                    <div className="form-check" key={key}>
+                                        <Controller
+                                            id={fieldData.id}
+                                            name={fieldData.id}
+                                            control={control}
+                                            render={({ field }) => (
+                                                <Input
+                                                    type="checkbox"
+                                                    className="form-check-input"
+                                                    disabled={fieldData.disabled}
+                                                    defaultChecked={field.value}
+                                                    {...field}
+                                                />
+                                            )}
+                                        />
+                                        <Label className="form-check-label">{fieldData.name}</Label>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                        <Button onClick={handleSubmit(onSubmit)} color="primary" block className="mt-2 mb-1">
+                            Define Status Report
+                        </Button>
+                    </Form>
+                </CardFooter>
+            </Card>
+        </div>
+    );
+}
+
+export default StatusReport;

--- a/client/src/views/pages/patient/StatusReport.js
+++ b/client/src/views/pages/patient/StatusReport.js
@@ -39,54 +39,44 @@ const primarySymptoms = [
     {
         name: "Fever",
         id: "fever",
-        disabled: false,
     },
     {
         name: "Cough",
         id: "cough",
-        disabled: false,
     },
     {
         name: "Shortness of Breath",
         id: "shortnessOfBreath",
-        disabled: false,
     },
     {
         name: "Loss of Taste and Smell",
         id: "lossOfTasteAndSmell",
-        disabled: false,
     },
 ];
 const secondarySymptoms = [
     {
         name: "Nausea",
         id: "nausea",
-        disabled: false,
     },
     {
         name: "Stomach Aches",
         id: "stomachAches",
-        disabled: false,
     },
     {
         name: "Vomiting",
         id: "vomiting",
-        disabled: false,
     },
     {
         name: "Headache",
         id: "headache",
-        disabled: false,
     },
     {
         name: "Muscle Pain",
         id: "musclePain",
-        disabled: false,
     },
     {
         name: "Sore Throat",
         id: "soreThroat",
-        disabled: false,
     },
 ];
 
@@ -175,11 +165,18 @@ function StatusReport() {
                                             name="temperature"
                                             control={control}
                                             render={({ field }) => (
-                                                <Input type="number" placeholder="&deg;C" invalid={!!errors.temperature} {...field} />
+                                                <Input
+                                                    type="number"
+                                                    placeholder="&deg;C"
+                                                    invalid={!!errors.temperature}
+                                                    {...field}
+                                                />
                                             )}
                                         />
                                         {errors.temperature && (
-                                            <FormFeedback className="d-block">{errors.temperature.message}</FormFeedback>
+                                            <FormFeedback className="d-block">
+                                                {errors.temperature.message}
+                                            </FormFeedback>
                                         )}
                                     </div>
                                 )}
@@ -193,7 +190,12 @@ function StatusReport() {
                                             name="weight"
                                             control={control}
                                             render={({ field }) => (
-                                                <Input type="number" placeholder="lbs" invalid={!!errors.weight} {...field} />
+                                                <Input
+                                                    type="number"
+                                                    placeholder="lbs"
+                                                    invalid={!!errors.weight}
+                                                    {...field}
+                                                />
                                             )}
                                         />
                                         {errors.weight && (
@@ -205,45 +207,51 @@ function StatusReport() {
                             <div className="d-flex mb-1">
                                 <div className="w-50 me-1">
                                     <Label className="form-label">Primary Symptoms</Label>
-                                    {primarySymptoms.map((fieldData, key) => fields[fieldData.id] && (
-                                        <div className="form-check" key={key}>
-                                            <Controller
-                                                id={fieldData.id}
-                                                name={fieldData.id}
-                                                control={control}
-                                                render={({ field }) => (
-                                                    <Input
-                                                        type="checkbox"
-                                                        className="form-check-input"
-                                                        checked={field.value}
-                                                        {...field}
+                                    {primarySymptoms.map(
+                                        (fieldData, key) =>
+                                            fields[fieldData.id] && (
+                                                <div className="form-check" key={key}>
+                                                    <Controller
+                                                        id={fieldData.id}
+                                                        name={fieldData.id}
+                                                        control={control}
+                                                        render={({ field }) => (
+                                                            <Input
+                                                                type="checkbox"
+                                                                className="form-check-input"
+                                                                checked={field.value}
+                                                                {...field}
+                                                            />
+                                                        )}
                                                     />
-                                                )}
-                                            />
-                                            <Label className="form-check-label">{fieldData.name}</Label>
-                                        </div>
-                                    ))}
+                                                    <Label className="form-check-label">{fieldData.name}</Label>
+                                                </div>
+                                            ),
+                                    )}
                                 </div>
                                 <div>
                                     <Label className="form-label">Secondary Symptoms</Label>
-                                    {secondarySymptoms.map((fieldData, key) => fields[fieldData.id] && (
-                                        <div className="form-check" key={key}>
-                                            <Controller
-                                                id={fieldData.id}
-                                                name={fieldData.id}
-                                                control={control}
-                                                render={({ field }) => (
-                                                    <Input
-                                                        type="checkbox"
-                                                        className="form-check-input"
-                                                        checked={field.value}
-                                                        {...field}
+                                    {secondarySymptoms.map(
+                                        (fieldData, key) =>
+                                            fields[fieldData.id] && (
+                                                <div className="form-check" key={key}>
+                                                    <Controller
+                                                        id={fieldData.id}
+                                                        name={fieldData.id}
+                                                        control={control}
+                                                        render={({ field }) => (
+                                                            <Input
+                                                                type="checkbox"
+                                                                className="form-check-input"
+                                                                checked={field.value}
+                                                                {...field}
+                                                            />
+                                                        )}
                                                     />
-                                                )}
-                                            />
-                                            <Label className="form-check-label">{fieldData.name}</Label>
-                                        </div>
-                                    ))}
+                                                    <Label className="form-check-label">{fieldData.name}</Label>
+                                                </div>
+                                            ),
+                                    )}
                                 </div>
                             </div>
                             {fields.otherSymptoms && (
@@ -255,9 +263,7 @@ function StatusReport() {
                                         id="otherSymptoms"
                                         name="otherSymptoms"
                                         control={control}
-                                        render={({ field }) => (
-                                            <Input type="textarea" {...field} />
-                                        )}
+                                        render={({ field }) => <Input type="textarea" {...field} />}
                                     />
                                 </div>
                             )}

--- a/client/src/views/pages/patient/StatusReport.js
+++ b/client/src/views/pages/patient/StatusReport.js
@@ -6,13 +6,13 @@ import * as yup from "yup";
 import axios from "axios";
 import { useSelector } from "react-redux";
 import { toast } from "react-toastify";
+import { useEffect, useState } from "react";
 
-async function defineStatusReport(data, token) {
-    const { patientId, ...fields } = data;
+async function submitStatusReport(data, patientId, token) {
     await axios.post(
-        `http://localhost:8080/patients/${patientId}/statuses/fields`,
+        `http://localhost:8080/patients/${patientId}/statuses`,
         {
-            ...fields,
+            ...data,
         },
         {
             headers: {
@@ -22,13 +22,78 @@ async function defineStatusReport(data, token) {
     );
 }
 
+async function getFields(patientId, token) {
+    const res = await axios.get(`http://localhost:8080/patients/${patientId}/statuses/fields`, {
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    });
+
+    return res.data;
+}
+
 const selectToken = (state) => state.auth.userData.token;
+const selectUserId = (state) => state.auth.userData.user.account.userId;
+
+const primarySymptoms = [
+    {
+        name: "Fever",
+        id: "fever",
+        disabled: false,
+    },
+    {
+        name: "Cough",
+        id: "cough",
+        disabled: false,
+    },
+    {
+        name: "Shortness of Breath",
+        id: "shortnessOfBreath",
+        disabled: false,
+    },
+    {
+        name: "Loss of Taste and Smell",
+        id: "lossOfTasteAndSmell",
+        disabled: false,
+    },
+];
+const secondarySymptoms = [
+    {
+        name: "Nausea",
+        id: "nausea",
+        disabled: false,
+    },
+    {
+        name: "Stomach Aches",
+        id: "stomachAches",
+        disabled: false,
+    },
+    {
+        name: "Vomiting",
+        id: "vomiting",
+        disabled: false,
+    },
+    {
+        name: "Headache",
+        id: "headache",
+        disabled: false,
+    },
+    {
+        name: "Muscle Pain",
+        id: "musclePain",
+        disabled: false,
+    },
+    {
+        name: "Sore Throat",
+        id: "soreThroat",
+        disabled: false,
+    },
+];
 
 function StatusReport() {
     const defaultValues = {
-        patientId: "",
-        temperature: true,
-        weight: true,
+        temperature: "",
+        weight: "",
         fever: false,
         cough: false,
         shortnessOfBreath: false,
@@ -39,91 +104,44 @@ function StatusReport() {
         headache: false,
         musclePain: false,
         soreThroat: false,
-        otherSymptoms: true,
+        otherSymptoms: "",
     };
 
-    const defineStatusReportSchema = yup.object().shape({
-        patientId: yup.number("Enter a patient ID.").typeError("Enter a patient ID.").required("Enter a patient ID."),
+    const statusReportSchema = yup.object().shape({
+        temperature: yup
+            .number("Enter a temperature.")
+            .typeError("Enter a temperature.")
+            .required("Enter a temperature."),
+        weight: yup.number("Enter a weight.").typeError("Enter a weight.").required("Enter a weight."),
     });
-
-    const primarySymptoms = [
-        {
-            name: "Fever",
-            id: "fever",
-            disabled: false,
-        },
-        {
-            name: "Cough",
-            id: "cough",
-            disabled: false,
-        },
-        {
-            name: "Shortness of Breath",
-            id: "shortnessOfBreath",
-            disabled: false,
-        },
-        {
-            name: "Loss of Taste and Smell",
-            id: "lossOfTasteAndSmell",
-            disabled: false,
-        },
-    ];
-    const secondarySymptoms = [
-        {
-            name: "Nausea",
-            id: "nausea",
-            disabled: false,
-        },
-        {
-            name: "Stomach Aches",
-            id: "stomachAches",
-            disabled: false,
-        },
-        {
-            name: "Vomiting",
-            id: "vomiting",
-            disabled: false,
-        },
-        {
-            name: "Headache",
-            id: "headache",
-            disabled: false,
-        },
-        {
-            name: "Muscle Pain",
-            id: "musclePain",
-            disabled: false,
-        },
-        {
-            name: "Sore Throat",
-            id: "soreThroat",
-            disabled: false,
-        },
-        {
-            name: "Other Symptoms",
-            id: "otherSymptoms",
-            disabled: true,
-        },
-    ];
 
     const {
         control,
         handleSubmit,
         reset,
         formState: { errors },
-    } = useForm({ defaultValues, resolver: yupResolver(defineStatusReportSchema) });
+    } = useForm({ defaultValues, resolver: yupResolver(statusReportSchema) });
 
     const token = useSelector(selectToken);
+    const userId = useSelector(selectUserId);
+    const [fields, setFields] = useState(null);
+    useEffect(() => {
+        async function f() {
+            const res = await getFields(userId, token);
+            setFields(res);
+        }
+        f();
+    }, [userId, token]);
 
     const onSubmit = async (data) => {
         try {
-            await defineStatusReport(data, token);
-            toast.success("Status Report Defined for a Patient", {
+            await submitStatusReport(data, userId, token);
+            toast.success("Status Report Submitted", {
                 position: "top-right",
                 autoClose: 5000,
             });
         } catch (error) {
-            toast.error("Status report could not be defined", {
+            toast.error("Status Report Could Not Be Submitted", {
                 position: "top-right",
                 autoClose: 5000,
             });
@@ -135,120 +153,118 @@ function StatusReport() {
     return (
         <div>
             <BreadCrumbsPage
-                breadCrumbTitle="Define Status Report"
+                breadCrumbTitle="Status Report"
                 breadCrumbParent="Patient"
-                breadCrumbActive="Define Status Report"
+                breadCrumbActive="Status Report"
             />
             <Card className="basic-card status-report-fields-card mx-auto">
                 <CardBody>
-                    <CardTitle className="mb-0">Define Status Report for a Patient</CardTitle>
+                    <CardTitle className="mb-0">Submit Status Report</CardTitle>
                 </CardBody>
-                <CardFooter>
-                    <Form>
-                        <div className="mb-1">
-                            <Label className="form-label" for="patientId">
-                                Patient ID
-                            </Label>
-                            <Controller
-                                id="patientId"
-                                name="patientId"
-                                control={control}
-                                render={({ field }) => (
-                                    <Input autoFocus type="number" invalid={!!errors.patientId} {...field} />
+                {fields && (
+                    <CardFooter>
+                        <Form>
+                            <div className="d-flex mb-1">
+                                {fields.temperature && (
+                                    <div className="w-50 me-1">
+                                        <Label className="form-label" for="temperature">
+                                            Temperature
+                                        </Label>
+                                        <Controller
+                                            id="temperature"
+                                            name="temperature"
+                                            control={control}
+                                            render={({ field }) => (
+                                                <Input type="number" invalid={!!errors.temperature} {...field} />
+                                            )}
+                                        />
+                                        {errors.temperature && (
+                                            <FormFeedback className="d-block">{errors.temperature.message}</FormFeedback>
+                                        )}
+                                    </div>
                                 )}
-                            />
-                            {errors.patientId && (
-                                <FormFeedback className="d-block">{errors.patientId.message}</FormFeedback>
+                                {fields.weight && (
+                                    <div className="w-50">
+                                        <Label className="form-label" for="temperature">
+                                            Weight
+                                        </Label>
+                                        <Controller
+                                            id="weight"
+                                            name="weight"
+                                            control={control}
+                                            render={({ field }) => (
+                                                <Input type="number" invalid={!!errors.weight} {...field} />
+                                            )}
+                                        />
+                                        {errors.weight && (
+                                            <FormFeedback className="d-block">{errors.weight.message}</FormFeedback>
+                                        )}
+                                    </div>
+                                )}
+                            </div>
+                            <div className="d-flex mb-1">
+                                <div className="w-50 me-1">
+                                    <Label className="form-label">Primary Symptoms</Label>
+                                    {primarySymptoms.map((fieldData, key) => fields[fieldData.id] && (
+                                        <div className="form-check" key={key}>
+                                            <Controller
+                                                id={fieldData.id}
+                                                name={fieldData.id}
+                                                control={control}
+                                                render={({ field }) => (
+                                                    <Input
+                                                        type="checkbox"
+                                                        className="form-check-input"
+                                                        {...field}
+                                                    />
+                                                )}
+                                            />
+                                            <Label className="form-check-label">{fieldData.name}</Label>
+                                        </div>
+                                    ))}
+                                </div>
+                                <div>
+                                    <Label className="form-label">Secondary Symptoms</Label>
+                                    {secondarySymptoms.map((fieldData, key) => fields[fieldData.id] && (
+                                        <div className="form-check" key={key}>
+                                            <Controller
+                                                id={fieldData.id}
+                                                name={fieldData.id}
+                                                control={control}
+                                                render={({ field }) => (
+                                                    <Input
+                                                        type="checkbox"
+                                                        className="form-check-input"
+                                                        {...field}
+                                                    />
+                                                )}
+                                            />
+                                            <Label className="form-check-label">{fieldData.name}</Label>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                            {fields.otherSymptoms && (
+                                <div>
+                                    <Label className="form-label" for="otherSymptoms">
+                                        Other Symptoms
+                                    </Label>
+                                    <Controller
+                                        id="otherSymptoms"
+                                        name="otherSymptoms"
+                                        control={control}
+                                        render={({ field }) => (
+                                            <Input type="textarea" {...field} />
+                                        )}
+                                    />
+                                </div>
                             )}
-                        </div>
-                        <div className="mb-1">
-                            <Label className="form-label">General</Label>
-                            <div className="d-flex">
-                                <div className="form-check w-50">
-                                    <Controller
-                                        id="temperature"
-                                        name="temperature"
-                                        control={control}
-                                        render={({ field }) => (
-                                            <Input
-                                                type="checkbox"
-                                                defaultChecked={field.value}
-                                                disabled={true}
-                                                {...field}
-                                            />
-                                        )}
-                                    />
-                                    <Label className="form-check-label">Temperature</Label>
-                                </div>
-                                <div className="form-check w-50">
-                                    <Controller
-                                        id="weight"
-                                        name="weight"
-                                        control={control}
-                                        render={({ field }) => (
-                                            <Input
-                                                type="checkbox"
-                                                defaultChecked={field.value}
-                                                disabled={true}
-                                                {...field}
-                                            />
-                                        )}
-                                    />
-                                    <Label className="form-check-label">Weight</Label>
-                                </div>
-                            </div>
-                        </div>
-                        <div className="d-flex">
-                            <div className="w-50 me-1">
-                                <Label className="form-label">Primary Symptoms</Label>
-                                {primarySymptoms.map((fieldData, key) => (
-                                    <div className="form-check" key={key}>
-                                        <Controller
-                                            id={fieldData.id}
-                                            name={fieldData.id}
-                                            control={control}
-                                            render={({ field }) => (
-                                                <Input
-                                                    type="checkbox"
-                                                    className="form-check-input"
-                                                    disabled={fieldData.disabled}
-                                                    defaultChecked={field.value}
-                                                    {...field}
-                                                />
-                                            )}
-                                        />
-                                        <Label className="form-check-label">{fieldData.name}</Label>
-                                    </div>
-                                ))}
-                            </div>
-                            <div>
-                                <Label className="form-label">Secondary Symptoms</Label>
-                                {secondarySymptoms.map((fieldData, key) => (
-                                    <div className="form-check" key={key}>
-                                        <Controller
-                                            id={fieldData.id}
-                                            name={fieldData.id}
-                                            control={control}
-                                            render={({ field }) => (
-                                                <Input
-                                                    type="checkbox"
-                                                    className="form-check-input"
-                                                    disabled={fieldData.disabled}
-                                                    defaultChecked={field.value}
-                                                    {...field}
-                                                />
-                                            )}
-                                        />
-                                        <Label className="form-check-label">{fieldData.name}</Label>
-                                    </div>
-                                ))}
-                            </div>
-                        </div>
-                        <Button onClick={handleSubmit(onSubmit)} color="primary" block className="mt-2 mb-1">
-                            Define Status Report
-                        </Button>
-                    </Form>
-                </CardFooter>
+                            <Button onClick={handleSubmit(onSubmit)} color="primary" block className="mt-2 mb-1">
+                                Submit
+                            </Button>
+                        </Form>
+                    </CardFooter>
+                )}
             </Card>
         </div>
     );

--- a/client/src/views/pages/patient/StatusReport.js
+++ b/client/src/views/pages/patient/StatusReport.js
@@ -175,7 +175,7 @@ function StatusReport() {
                                             name="temperature"
                                             control={control}
                                             render={({ field }) => (
-                                                <Input type="number" invalid={!!errors.temperature} {...field} />
+                                                <Input type="number" placeholder="&deg;C" invalid={!!errors.temperature} {...field} />
                                             )}
                                         />
                                         {errors.temperature && (
@@ -193,7 +193,7 @@ function StatusReport() {
                                             name="weight"
                                             control={control}
                                             render={({ field }) => (
-                                                <Input type="number" invalid={!!errors.weight} {...field} />
+                                                <Input type="number" placeholder="lbs" invalid={!!errors.weight} {...field} />
                                             )}
                                         />
                                         {errors.weight && (
@@ -215,6 +215,7 @@ function StatusReport() {
                                                     <Input
                                                         type="checkbox"
                                                         className="form-check-input"
+                                                        checked={field.value}
                                                         {...field}
                                                     />
                                                 )}
@@ -235,6 +236,7 @@ function StatusReport() {
                                                     <Input
                                                         type="checkbox"
                                                         className="form-check-input"
+                                                        checked={field.value}
                                                         {...field}
                                                     />
                                                 )}


### PR DESCRIPTION
JIRA: https://soen-390-covid-tracker.atlassian.net/browse/COV-25

## Changes
- Add front end page that gets the patients status fields and filters by the required one
- Integrates with backend api
- Update some routes with missing authorization meta data
- Update navbar to get user profile on refresh, this is so the role of the user can be updated with out them having to sign out then sign in again
- Fixed form reset not resetting checkboxes

## Screenshots
![image](https://user-images.githubusercontent.com/19786843/154861587-af59d2b3-c0e9-4d2b-a222-2e16da0d2a8f.png)
![image](https://user-images.githubusercontent.com/19786843/154861590-db7506a1-1a1f-4498-9133-a311bac42ed9.png)
![image](https://user-images.githubusercontent.com/19786843/154861598-64cdd16b-b0c8-481d-89f9-7fc00a501e1c.png)
